### PR TITLE
display months and years in expiration time remaining

### DIFF
--- a/tiers/models.py
+++ b/tiers/models.py
@@ -66,7 +66,7 @@ class Tier(TimeStampedModel):
         rd = relativedelta(self.tier_expires_at, timezone.now())
         if abs(rd.years) != 0:
             return "{0} year, {1} months, {2} days and {3} hours".format(abs(rd.years), abs(rd.months), abs(rd.days), abs(rd.hours))
-        if abs(rd.months) != 0:
+        elif abs(rd.months) != 0:
             return "{0} months, {1} days and {2} hours".format(abs(rd.months), abs(rd.days), abs(rd.hours))
         elif abs(rd.days) != 0:
             return "{0} days and {1} hours".format(abs(rd.days), abs(rd.hours))

--- a/tiers/models.py
+++ b/tiers/models.py
@@ -64,7 +64,11 @@ class Tier(TimeStampedModel):
     def time_til_tier_expires(self):
         """Pretty prints time left til expiration"""
         rd = relativedelta(self.tier_expires_at, timezone.now())
-        if abs(rd.days) != 0:
+        if abs(rd.years) != 0:
+            return "{0} year, {1} months, {2} days and {3} hours".format(abs(rd.years), abs(rd.months), abs(rd.days), abs(rd.hours))
+        if abs(rd.months) != 0:
+            return "{0} months, {1} days and {2} hours".format(abs(rd.months), abs(rd.days), abs(rd.hours))
+        elif abs(rd.days) != 0:
             return "{0} days and {1} hours".format(abs(rd.days), abs(rd.hours))
         else:
             return "{0} hours".format(abs(rd.hours))


### PR DESCRIPTION
This is to address a bug in the expiration time remaining. The current output string only considers days and hours, we're having issues when we extend the trial to months, and we only see the remaining days and hours, which is not accurate.