### PR TITLE
Use Django timeuntil instead of custom code

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,4 +2,5 @@ tox==2.6.0
 factory-boy>=2.6.0,<3.0.0
 pytest==3.0.6
 pytest-django==3.1.2
-
+freezegun==0.3.11
+pytz==2018.9

--- a/tiers/models.py
+++ b/tiers/models.py
@@ -2,11 +2,11 @@ from datetime import timedelta
 from functools import wraps
 
 from django.utils import timezone
+from django.utils.timesince import timeuntil
 from django.db import models
 
 from .app_settings import ORGANIZATION_MODEL
 
-from dateutil.relativedelta import relativedelta
 from model_utils.models import TimeStampedModel
 from model_utils import Choices
 
@@ -63,14 +63,4 @@ class Tier(TimeStampedModel):
     @check_if_exempt
     def time_til_tier_expires(self):
         """Pretty prints time left til expiration"""
-        rd = relativedelta(self.tier_expires_at, timezone.now())
-        if abs(rd.years) != 0:
-            return "{0} year, {1} months, {2} days and {3} hours".format(abs(rd.years), abs(rd.months), abs(rd.days), abs(rd.hours))
-        elif abs(rd.months) != 0:
-            return "{0} months, {1} days and {2} hours".format(abs(rd.months), abs(rd.days), abs(rd.hours))
-        elif abs(rd.days) != 0:
-            return "{0} days and {1} hours".format(abs(rd.days), abs(rd.hours))
-        else:
-            return "{0} hours".format(abs(rd.hours))
-
-
+        return timeuntil(self.tier_expires_at)

--- a/tiers/tests/factories.py
+++ b/tiers/tests/factories.py
@@ -1,9 +1,7 @@
-from datetime import datetime, timedelta
-
 import factory
 from factory.django import DjangoModelFactory
 
-from tiers.models import Tier, set_default_expiration
+from tiers.models import Tier
 from fake_organizations.models import Organization
 
 
@@ -18,10 +16,5 @@ class TierFactory(DjangoModelFactory):
     class Meta(object):
         model = Tier
 
-    name = Tier.TIERS.TRIAL
     organization = factory.SubFactory(OrganizationFactory)
-
-    tier_enforcement_exempt = False
-    tier_enforcement_grace_period = 14
-    tier_expires_at = datetime.now() + timedelta(days=30)
 

--- a/tiers/tests/test_tiers.py
+++ b/tiers/tests/test_tiers.py
@@ -1,9 +1,14 @@
-from datetime import datetime, timedelta
+from __future__ import unicode_literals
 
-import pytest
+import re
+
+from datetime import datetime, timedelta
+from django.utils.timezone import now as timezone_now
+
+from freezegun import freeze_time
 
 from tiers.tests.utils import TiersTestCaseBase
-from tiers.tests.factories import OrganizationFactory, TierFactory
+from tiers.tests.factories import TierFactory
 
 
 class TiersTests(TiersTestCaseBase):
@@ -34,3 +39,27 @@ class TiersTests(TiersTestCaseBase):
         assert t.has_tier_expired() == False
         assert t.has_tier_grace_period_expired() == False
 
+    def test_expire_message(self):
+        """
+        Ensures that `has_tier_grace_period_expired` works well.
+
+        This function uses regexps match what the Django `timeuntil` returns.
+        The `avoid_wrapping` function has more details in the docstring.
+        """
+        with freeze_time(datetime(2019, 2, 5)):
+            t = TierFactory.create()
+            assert datetime.now() == datetime(2019, 2, 5), 'Ensure that freeze works'
+            assert timezone_now() == datetime(2019, 2, 5), 'Ensure that freeze works'
+            assert t.tier_expires_at == datetime(2019, 3, 7)
+
+        with freeze_time(datetime(2019, 2, 6)):
+            message = t.time_til_tier_expires()
+            assert re.match('4.*weeks,.*1.*day', message), 'Should handle long time well'
+
+        with freeze_time(datetime(2019, 3, 4, 0, 8, 0)):
+            message = t.time_til_tier_expires()
+            assert re.match(r'2.*days,.*23.*hours', message), 'Should short time well'
+
+        with freeze_time(datetime(2020, 2, 6)):
+            message = t.time_til_tier_expires()
+            assert re.match('0.*minutes', message), 'Should handle future time well.'


### PR DESCRIPTION
I'm not super sure that will fix the issue.

I couldn't reproduce the issue locally, that's why, but I found that `django.utils.timesince.timeuntil` handles `is_aware` for dates without timezones.

Trello Card: [Tahoe Trial: incorrect expiration date displayed for trial users](https://trello.com/c/MmsPP3DZ/3494-4-tahoe-trial-incorrect-expiration-date-displayed-for-trial-users)