### PR TITLE
bump Django to >= 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: python
+dist: xenial
 sudo: false
 python:
   - "3.6"
   - "2.7"
+env:
+  - DJANGO="Django>=1.11,<2"
+#   - DJANGO="Django>=2.0"
+# matrix:
+#   exclude:
+#   - python: '2.7'
+#     env: DJANGO="Django>=2.0"
+
 install:
   - pip install -r requirements.txt
+  - pip install $DJANGO
   - pip install pytest-cov
 script:
   - py.test --junitxml=results.xml --cov=./

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     packages=find_packages(exclude=['tests', 'fake_organizations']),
     install_requires=[
-        'django>=1.8,<1.11',
+        'django<2',
         'django-model-utils<=2.3.1',
         'python-dateutil<=2.6.0',
     ],


### PR DESCRIPTION
Django versions < 1.11 are no longer secure (we get a security alert on this repo from that). I just relaxed the restriction in `setup.py`.

I've also got some Travis setup in place for testing on Django 2 (it doesn't yet work there, so it's commented out for now) since that will be coming up at some point.