### PR TITLE
automatically deploy package to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,13 @@ script:
   - flake8 tiers
   - py.test --junitxml=results.xml --cov=./
   - bash <(curl -s https://codecov.io/bash)
+
+deploy:
+  provider: pypi
+  user: "appsembler"
+  password:
+    secure: "rZWFGfr/pxBrezKnznvWFs1zyXRqWvCvaTuRIbItcmwUuTxGy85P9PCutDKrRgfTvfgHoCQCGypkHSm8myT5paK/qnPzp6uLwYSUQXcsPzMOosugN1izT8Tv8ouYmeMC9AytTqpb2QLsBTN5DSF0ZHf69yVEt4UWr4eweEppl105WayXxR1MkitF05qb7OOkgiCWvcMQgCsqrTgBdV8z4vP2n2TlWkTlbiZKyFrXJZzS9iWduk/VEux23Z+8ZVNqpdlaBBu7xEztsDvOMG35/m+wlbw1Aho1BsneYiyTihNW/Hqj9H3s1wbm/AE25MNJB0urdFz/rpUhxzudocGB+hl7fWCXDgWlsdvveFnSWzg8p9ZpgUt53nPn03PU3+0X981v6P3MdjmP1x494hVL/UeJCk/kGuPdvilPZLJOz/PWr6Qh2h9ZQPgC3FKCpEuuvT3Bv6dsQUnCbbe7VsG5R626QiWR85BlORpKGM0ElB94UCJGc2R14HwKeiRIRElwA3LOiPMQ6Yy1l0FYRM2tUAle0mnoXVw2oVUJuEDcp7EedW6ALzJk6IU+8NKDm3dFJla7RG0MhYnk168ct/d2dXZWUUdz19hWi2HWXlZ/BaCyO8IYYfNxBXJjq4CTywIEdYEP1O+bK/Bg4u2Wx7pivat/QnNS1SjrZlmHJC7zMT8="
+  on:
+    tags: true
+  distributions: "sdist bdist_wheel"
+  skip_existing: true


### PR DESCRIPTION
PyPI deployment automated through TravisCI. Documentation on how to trigger a release are in the wiki as a [Runbook entry](https://appsembler-infrastructure.appspot.com/post/runbook-new-pypi-release/)