### PR TITLE
flake8 in tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ install-test-deps:
 	@pip install -r test_requirements.txt
 
 test:
-	@PYTHON_INTERPRETER_36=/usr/bin/python3.6 tox
-	@rm -rf test.db
+	@tox
 
 clean:
 	@rm -rf .cache

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py36, flake8
 skipsdist = True
 
 [testenv]
@@ -8,5 +8,8 @@ deps = -r{toxinidir}/test_requirements.txt
 commands =
     py.test --quiet {posargs}
 
-[testenv:py36]
-basepython = {env:PYTHON_INTERPRETER_36}
+[testenv:flake8]
+deps =
+    flake8==3.7.9
+commands =
+    flake8 tiers

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps = -r{toxinidir}/test_requirements.txt
 commands =
     py.test --quiet {posargs}
 
-[testenv:flake8]
+[flake8]
 deps =
     flake8==3.7.9
 commands =


### PR DESCRIPTION
Just a small one in my ongoing effort to have `tox` be our universal command for running tests.

* have tox run flake8 as well
* remove an unnecessary py36 stanza from the config (not sure what it was supposed to be doing. just generated an error on my machine. removing it lets that testenv run)