### PR TITLE
support django 1.10+ style middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ python:
   - "2.7"
 env:
   - DJANGO="Django>=1.11,<2"
-  - DJANGO="Django>=2.0"
-matrix:
-  exclude:
-  - python: '2.7'
-    env: DJANGO="Django>=2.0"
+#   - DJANGO="Django>=2.0"
+# matrix:
+#   exclude:
+#   - python: '2.7'
+#     env: DJANGO="Django>=2.0"
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ python:
   - "2.7"
 env:
   - DJANGO="Django>=1.11,<2"
-#   - DJANGO="Django>=2.0"
-# matrix:
-#   exclude:
-#   - python: '2.7'
-#     env: DJANGO="Django>=2.0"
+  - DJANGO="Django>=2.0"
+matrix:
+  exclude:
+  - python: '2.7'
+    env: DJANGO="Django>=2.0"
 
 install:
   - pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Added supoort for Django 1.10+ style middleware
+
+## [0.0.20] - 2019-11-06
+
+- starting changelog
+
+[unreleased]: https://github.com/appsembler/django-tiers/compare/v0.0.20...HEAD
+[0.0.20]: https://github.com/appsembler/django-tiers/releases/tag/v0.0.20

--- a/test_settings.py
+++ b/test_settings.py
@@ -25,12 +25,12 @@ INSTALLED_APPS = (
 
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-)
+]
 
 TIERS_ORGANIZATION_MODEL = 'fake_organizations.Organization'
 TIERS_EXPIRED_REDIRECT_URL = "/"

--- a/tiers/middleware.py
+++ b/tiers/middleware.py
@@ -2,6 +2,7 @@ import logging
 
 from django.shortcuts import redirect
 from django.core.urlresolvers import NoReverseMatch, reverse
+from django.utils.deprecation import MiddlewareMixin
 
 from .models import Tier
 from .app_settings import EXPIRED_REDIRECT_URL, ORGANIZATION_TIER_GETTER_NAME
@@ -10,7 +11,7 @@ from .app_settings import EXPIRED_REDIRECT_URL, ORGANIZATION_TIER_GETTER_NAME
 log = logging.getLogger(__name__)
 
 
-class TierMiddleware(object):
+class TierMiddleware(MiddlewareMixin):
     """
     Django Tiers middleware
     """


### PR DESCRIPTION
allows us to switch from `MIDDLEWARE_CLASSES` to `MIDDLEWARE` and removes deprecation warning.