### PR TITLE
remove a django 2 deprecation warning:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ python:
   - "2.7"
 env:
   - DJANGO="Django>=1.11,<2"
-#   - DJANGO="Django>=2.0"
-# matrix:
-#   exclude:
-#   - python: '2.7'
-#     env: DJANGO="Django>=2.0"
+  - DJANGO="Django>=2.0,<3"
+matrix:
+  exclude:
+  - python: '2.7'
+    env: DJANGO="Django>=2.0,<3"
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ python:
   - "2.7"
 env:
   - DJANGO="Django>=1.11,<2"
-  - DJANGO="Django>=2.0,<3"
-matrix:
-  exclude:
-  - python: '2.7'
-    env: DJANGO="Django>=2.0,<3"
+#   - DJANGO="Django>=2.0,<3"
+# matrix:
+#   exclude:
+#   - python: '2.7'
+#     env: DJANGO="Django>=2.0,<3"
 
 install:
   - pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added basic honeycomb instrumentation to middleware
+- Removed a Django 2 deprecation warning
 
 ## [0.1.0] - 2020-06-04
 

--- a/tiers/middleware.py
+++ b/tiers/middleware.py
@@ -39,7 +39,7 @@ class TierMiddleware(MiddlewareMixin):
             pass
 
         # Nothing to do if the user is not logged in
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return
 
         # If the user has superuser privileges don't do anything

--- a/tiers/middleware.py
+++ b/tiers/middleware.py
@@ -1,8 +1,8 @@
 import logging
 
 from django.shortcuts import redirect
-from django.core.urlresolvers import NoReverseMatch, reverse
 from django.utils.deprecation import MiddlewareMixin
+from django.urls import NoReverseMatch, reverse
 
 from .models import Tier
 from .app_settings import EXPIRED_REDIRECT_URL, ORGANIZATION_TIER_GETTER_NAME


### PR DESCRIPTION
```
RemovedInDjango20Warning: Using user.is_authenticated() and user.is_anonymous() as a method is deprecated. Remove the parentheses to use it as an attribute.
```