### PR TITLE
add on_delete in migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ python:
   - "2.7"
 env:
   - DJANGO="Django>=1.11,<2"
-#   - DJANGO="Django>=2.0,<3"
-# matrix:
-#   exclude:
-#   - python: '2.7'
-#     env: DJANGO="Django>=2.0,<3"
+  - DJANGO="Django>=2.0,<3"
+matrix:
+  exclude:
+  - python: '2.7'
+    env: DJANGO="Django>=2.0,<3"
 
 install:
   - pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added basic honeycomb instrumentation to middleware
 - Removed a Django 2 deprecation warning
 - Added testing against Python 3.8
+- Added testing against Django 2.x
 
 ## [0.1.0] - 2020-06-04
 

--- a/tiers/migrations/0001_initial.py
+++ b/tiers/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('tier_enforcement_exempt', models.BooleanField(default=False)),
                 ('tier_enforcement_grace_period', models.PositiveIntegerField(default=14)),
                 ('tier_expires_at', models.DateTimeField(default=tiers.models.set_default_expiration)),
-                ('organization', models.OneToOneField(related_name='tier', to=ORGANIZATION_MODEL)),
+                ('organization', models.OneToOneField(related_name='tier', to=ORGANIZATION_MODEL, on_delete=models.deletion.DO_NOTHING)),
             ],
             options={
                 'abstract': False,

--- a/tiers/migrations/0002_auto_20170321_1856.py
+++ b/tiers/migrations/0002_auto_20170321_1856.py
@@ -21,6 +21,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='tier',
             name='organization',
-            field=models.OneToOneField(related_name='tier', null=True, blank=True, to=ORGANIZATION_MODEL),
+            field=models.OneToOneField(related_name='tier', null=True, blank=True, to=ORGANIZATION_MODEL, on_delete=models.deletion.DO_NOTHING),
         ),
     ]


### PR DESCRIPTION
Add the `on_delete` argument to migrations that Django 2.0 requires.

That appears to be the final blocker on 2.0 support, so I've also added Django 2.x tests to the TravisCI matrix.