### PR TITLE
Fix devstack issues: django-model-utils and python-dateutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+ - Remove setup.py package restrictions (fixes appsembler/devstack#50)
 
 ## [0.2.1] - 2020-09-09
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(exclude=['tests', 'fake_organizations']),
     install_requires=[
         'django<3',
-        'django-model-utils<=2.3.1',
-        'python-dateutil<=2.8.1',
+        'django-model-utils',
+        'python-dateutil',
     ],
 )


### PR DESCRIPTION
Remove restrictions for django-model-utils and python-dateutil

Fixes https://github.com/appsembler/devstack/issues/50

This should fix the issue in devstack: 
 - [LMS pages show TypeError exception](https://appsembler.atlassian.net/wiki/spaces/BLA/pages/786366550/How+to+set+up+a+Tahoe+Devstack+using+Sultan#LMS-pages-show-TypeError-exception) error instructions.