### PR TITLE
Add more details when a tier error happens

### DIFF
--- a/tiers/middleware.py
+++ b/tiers/middleware.py
@@ -69,7 +69,7 @@ class TierMiddleware(MiddlewareMixin):
             # fail silently. This should not happen. We should always automatically create
             # a tier for each organization.
             beeline.add_context_field("tiers.organization_without_tier", True)
-            log.warning("Organization wihout Tier: {0}".format(org))
+            log.exception("Organization has a problem with its Tier: {0}".format(org))
             return
 
         # Only display expiration warning for Trial tiers for now


### PR DESCRIPTION
Add more details to Tier errors that shows up in the logs like:

```
Organization wihout Tier: xyz-org (xyz-org)
  File "...django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)

Message: 'Uncaught exception from None'
Arguments: ()" 
```

This fix logs the original exception instead of hiding it behind a generic error message (as seen in the example above) .

### TODO
  - [x] Run tests locally