### PR TITLE
update test requirements

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,14 +1,14 @@
-tox==3.17.0
-factory-boy==2.12.0
+tox==3.23.1
+factory-boy==3.2.0
 pytest==4.6
-pytest-cov==2.11.0
-pytest-django==3.2.1
-pytz==2020.1
-mock==3.0.5
-django-model-utils==2.3.1
+pytest-cov==2.12.1
+pytest-django==4.4.0
+pytz==2021.1
+mock==4.0.3
+django-model-utils==4.1.1
 python-dateutil==2.8.1
-flake8==3.8.3
-django-waffle==0.18.0
+flake8==3.9.2
+django-waffle==2.2.0
 
 # XBlock dependencies to make testing easier
 # mostly to import workbench.settings

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,10 +1,10 @@
 tox==3.23.1
-factory-boy==3.2.0
+factory-boy==2.12.0
 pytest==4.6
-pytest-cov==2.12.1
-pytest-django==4.4.0
+pytest-cov==2.11.0
+pytest-django==3.2.1
 pytz==2021.1
-mock==4.0.3
+mock==3.0.5
 django-model-utils==4.1.1
 python-dateutil==2.8.1
 flake8==3.9.2

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,6 @@ commands =
 
 [testenv:flake8]
 deps =
-    flake8==3.8.3
+    flake8==3.9.2
 commands =
     flake8 tiers


### PR DESCRIPTION
Use latest versions of all libraries for tests where possible. Some still have conflicts with python 3.5 (`factory-boy`, `pytest-cov`, `pytest-django`, `mock`), so those will have to wait until we can drop support for python 3.5 (or go to the trouble of installing different sets of dependencies in each test environment).