### PR TITLE
 Admin filter for active tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -6,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.6] - 2021-07-02
+ - Add Django admin filters for active/inactive tiers (does not respect tier graceperiod)
+
+## [0.2.5] - 2021-06-14
+ - Add automated pypi publishing via GitHub Actions
 
 ## [0.2.4] - 2021-06-10
 
@@ -45,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - starting changelog
 
 [unreleased]: https://github.com/appsembler/django-tiers/compare/v0.2.4...HEAD
+[0.2.6]: https://github.com/appsembler/django-tiers/compare/v0.2.5...v0.2.6
+[0.2.5]: https://github.com/appsembler/django-tiers/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/appsembler/django-tiers/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/appsembler/django-tiers/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/appsembler/django-tiers/compare/v0.2.1...v0.2.2

--- a/tiers/__init__.py
+++ b/tiers/__init__.py
@@ -1,4 +1,4 @@
 """
 django-tiers initialization module
 """
-__version__ = '0.2.5'  # pragma: no cover
+__version__ = '0.2.6'  # pragma: no cover

--- a/tiers/admin.py
+++ b/tiers/admin.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
+
+
 from django.contrib import admin
+from django.contrib.admin import SimpleListFilter
+from django.db.models import Q
+from django.utils import timezone
 
 from .models import Tier
 
@@ -11,11 +16,39 @@ def make_exempt(modeladmin, request, queryset):
 make_exempt.short_description = "Exempt from tier enforcement"
 
 
+class ActiveTierFilter(SimpleListFilter):
+    """
+    Admin filter for tier active/inactive status.
+
+    TODO: Add support for graceperiod
+    """
+
+    title = 'Tier status'
+    parameter_name = 'tier_status'
+
+    STATUS_ACTIVE = 'active'
+    STATUS_INACTIVE = 'inactive'
+
+    def lookups(self, request, model_admin):
+        return [
+            [self.STATUS_ACTIVE, 'Active Tiers'],
+            [self.STATUS_INACTIVE, 'Inactive Tiers'],
+        ]
+
+    def queryset(self, request, queryset):
+        active_tiers_filter = Q(tier_enforcement_exempt=True) | Q(tier_expires_at__gte=timezone.now())
+        if self.value() == self.STATUS_ACTIVE:
+            queryset = queryset.filter(active_tiers_filter)
+        elif self.value() == self.STATUS_INACTIVE:
+            queryset = queryset.exclude(active_tiers_filter)
+        return queryset
+
+
 class TierAdmin(admin.ModelAdmin):
     list_display = ('organization', 'get_microsites', 'name', 'tier_expires_at',
                     'tier_enforcement_grace_period', 'tier_enforcement_exempt',)
     search_fields = ['organization__name', 'name']
-    list_filter = ['name', 'tier_expires_at']
+    list_filter = ['name', ActiveTierFilter, 'tier_expires_at', 'tier_enforcement_exempt']
     actions = [make_exempt]
 
     def get_microsites(self, obj):

--- a/tiers/tests/test_admin.py
+++ b/tiers/tests/test_admin.py
@@ -1,0 +1,37 @@
+from datetime import timedelta
+from unittest.mock import Mock
+
+from django.utils import timezone
+from tiers.models import Tier
+from tiers.tests.factories import TierFactory
+from tiers.admin import ActiveTierFilter
+
+
+def test_active_tier_filter_lookup_choices():
+    filter = ActiveTierFilter(Mock(), {}, Mock(), Mock())
+    assert filter.lookups(Mock(), Mock()) == [
+        ['active', 'Active Tiers'],
+        ['inactive', 'Inactive Tiers'],
+    ]
+
+
+def test_active_tier_filter_queryset(db):
+    past_date = timezone.now() - timedelta(days=100)
+    future_date = timezone.now() + timedelta(days=100)
+    expired_inactive_tier = TierFactory.create(tier_enforcement_exempt=False, tier_expires_at=past_date)
+    exempted_active_tier = TierFactory.create(tier_enforcement_exempt=True, tier_expires_at=past_date)
+    active_tier = TierFactory.create(tier_enforcement_exempt=True, tier_expires_at=future_date)
+    tiers = Tier.objects.all()
+
+    active_filter = ActiveTierFilter(Mock(), {'tier_status': 'active'}, Mock(), Mock())
+    assert active_tier in active_filter.queryset(Mock(), tiers), 'Should only return active tiers'
+    assert exempted_active_tier in active_filter.queryset(Mock(), tiers), 'Should only return active tiers'
+    assert expired_inactive_tier not in active_filter.queryset(Mock(), tiers), 'Should only return active tiers'
+
+    inactive_filter = ActiveTierFilter(Mock(), {'tier_status': 'inactive'}, Mock(), Mock())
+    assert active_tier not in inactive_filter.queryset(Mock(), tiers), 'Should only return inactive tiers'
+    assert exempted_active_tier not in inactive_filter.queryset(Mock(), tiers), 'Should only return inactive tiers'
+    assert expired_inactive_tier in inactive_filter.queryset(Mock(), tiers), 'Should only return inactive tiers'
+
+    all_filter = ActiveTierFilter(Mock(), {}, Mock(), Mock())
+    assert len(all_filter.queryset(Mock(), tiers)) == 3, 'Should return all tiers'


### PR DESCRIPTION
RED-2313: This helps CSMs to quickly find active old active tiers and remove them.

### Screenshot
![image](https://user-images.githubusercontent.com/645156/124301922-285a7d00-db69-11eb-822d-3a03218a3397.png)

### Testing
 - [x] Tested on devstack
 - [x] Automated tests
 - [ ] This feature will be installed on AMC staging and tested

### No `tier_enforcement_grace_period` support?

This is substandard and needs to be fixed. However the `get_active_sites` don't support `tier_enforcement_grace_period` either. 

I'm thinking of disabling support for `tier_enforcement_grace_period` altogether: https://github.com/appsembler/django-tiers/issues/36