### PR TITLE
TierInfo to prepare for removing db models

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
-addopts = --junitxml=results.xml --cov=tiers
+addopts = --junitxml=results.xml --cov=tiers --cov-report=term-missing --cov-report=html

--- a/tiers/middleware.py
+++ b/tiers/middleware.py
@@ -5,7 +5,6 @@ from django.utils.deprecation import MiddlewareMixin
 from django.urls import NoReverseMatch, reverse
 
 from .helpers import is_equal_or_sub_url, is_white_listed_url
-from .models import Tier
 from .app_settings import settings
 from .waffle_utils import should_redirect_non_authenticated
 
@@ -61,9 +60,11 @@ class TierMiddleware(MiddlewareMixin):
         try:
             organization_tier_getter_name = settings.organization_tier_getter_name()
             if organization_tier_getter_name:
+                # TODO: Refactor into a helper to get `TierInfo` directly within `edx-organizations` or LMS
                 tier = org.__getattribute__(organization_tier_getter_name)()
+                tier_info = tier.get_tier_info()
             else:
-                tier = org.tier
+                tier_info = org.tier.get_tier_info()
         except Exception:
             # If the organization for some reason does not have a tier assigned
             # fail silently. This should not happen. We should always automatically create
@@ -73,18 +74,17 @@ class TierMiddleware(MiddlewareMixin):
             return
 
         # Only display expiration warning for Trial tiers for now
-        request.session['DISPLAY_EXPIRATION_WARNING'] = ((tier.name == Tier.TIERS.TRIAL) and
-                                                         (not tier.tier_enforcement_exempt))
-        request.session['TIER_EXPIRES_IN'] = tier.time_til_tier_expires()
+        request.session['DISPLAY_EXPIRATION_WARNING'] = tier_info.should_show_expiration_warning()
+        request.session['TIER_EXPIRES_IN'] = tier_info.time_til_expiration()
         beeline.add_context_field("tiers.tier_expires_in", request.session['TIER_EXPIRES_IN'])
         # TODO: I'm not sure if we have to refresh the session info at this point somehow.
-        request.session['TIER_EXPIRED'] = tier.has_tier_expired()
+        request.session['TIER_EXPIRED'] = tier_info.has_subscription_ended()
         beeline.add_context_field("tiers.tier_expired", request.session['TIER_EXPIRED'])
         # TODO: We should use request.TIER_NAME instead of meddling the session, but being consistent for now
-        request.session['TIER_NAME'] = tier.name
-        beeline.add_context_field("tiers.tier_name", tier.name)
+        request.session['TIER_NAME'] = tier_info.tier
+        beeline.add_context_field("tiers.tier_name", tier_info.tier)
 
         # TODO: I'm not sure if we have to refresh the session info at this point somehow.
-        if tier.has_tier_expired():
+        if tier_info.has_subscription_ended():
             if expired_redirect_url and not is_white_listed_url(request.path):
                 return redirect(expired_redirect_url)

--- a/tiers/tests/test_tiers.py
+++ b/tiers/tests/test_tiers.py
@@ -24,6 +24,10 @@ class TiersTests(TestCase):
         assert t.tier_enforcement_exempt is False
         assert t.has_tier_expired() is False
 
+    def test_tier_str(self):
+        t = TierFactory()
+        assert 'Tier <org:' in str(t)
+
     def test_expired_tier(self):
         t = TierFactory(tier_expires_at=(datetime.now() - timedelta(days=2)))
         assert t.tier_enforcement_exempt is False

--- a/tiers/tier_info.py
+++ b/tiers/tier_info.py
@@ -1,0 +1,61 @@
+"""
+Tier helper and calculation classes with no model dependency.
+"""
+from collections import namedtuple
+
+from django.utils import timezone
+from django.utils.timesince import timeuntil
+
+TierTuple = namedtuple('TierTuple', ['id', 'name'])
+
+
+class TierInfo:
+    """
+    Tier info and calculator class.
+
+    TODO: Move into the Site Configuration Client package.
+    """
+
+    TRIAL = TierTuple('trial', 'Trial')  # Expires in 30 days
+    BASIC = TierTuple('basic', 'Basic')
+    PRO = TierTuple('pro', 'Professional')
+    PREMIUM = TierTuple('premium', 'Premium')
+
+    TIERS = (
+        TRIAL,
+        BASIC,
+        PRO,
+        PREMIUM,
+    )
+
+    def __init__(self, tier, subscription_ends, always_active):
+        self.tier = tier
+        self.subscription_ends = subscription_ends
+        self.always_active = always_active
+
+    def has_subscription_ended(self, now=None):
+        """Helper function that checks whether a subscription has expired"""
+        if self.always_active:
+            return False
+
+        if not now:
+            now = timezone.now()
+
+        return now > self.subscription_ends
+
+    def should_show_expiration_warning(self):
+        """Decide if expiration warning is needed."""
+        if self.always_active:
+            return False
+
+        return self.tier == self.TRIAL.id
+
+    def time_til_expiration(self, now=None):
+        """Pretty prints time left til expiration"""
+        if self.always_active:
+            return False
+
+        if not now:
+            now = timezone.now()
+
+        return timeuntil(self.subscription_ends, now)


### PR DESCRIPTION
Preparing for integration with Site Configuration Client: 

 - as explained in: https://appsembler.atlassian.net/wiki/spaces/RT/pages/2476572686/%60django-tiers%60+Site+Config+integration?search_id=d3954fe1-d7f2-4cd3-bdbd-208bc9cae092

The change is mostly benign and has no side effect.

The next change will be to refactor `TIERS_ORGANIZATION_TIER_GETTER_NAME` to be a barebones function instead of a method within `Organization`.